### PR TITLE
fix(auth): Critical - Restore Auth Flow with createBrowserClient

### DIFF
--- a/src/lib/supabase/browser.ts
+++ b/src/lib/supabase/browser.ts
@@ -1,49 +1,11 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
-// Use stub types until migrations 014-019 are applied
-// TODO: After migrations, regenerate: npx supabase gen types typescript --linked
+import { createBrowserClient } from '@supabase/ssr';
 import type { Database } from './database.types.stub';
 
-// Singleton instance pentru a preveni multiple GoTrueClient instances
-let browserClient: SupabaseClient<Database> | null = null;
-
-// Obține clientul Supabase pentru browser (SINGLETON PATTERN)
 export function getBrowserSupabase() {
-  // Returnează instanța existentă dacă există deja
-  if (browserClient) {
-    return browserClient;
-  }
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!supabaseUrl || !supabaseKey) {
-    throw new Error(
-      'Missing Supabase environment variables. Please check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY'
-    );
-  }
-
-  // Crează instanța DOAR o singură dată
-  browserClient = createClient<Database>(supabaseUrl, supabaseKey, {
-    auth: {
-      autoRefreshToken: true,
-      persistSession: true,
-      detectSessionInUrl: true,
-      flowType: 'pkce',
-      storageKey: 'swaply-auth', // Consistent storage key
-    },
-    global: {
-      headers: {
-        'X-Client-Info': 'swaply-web'
-      }
-    },
-    realtime: {
-      params: {
-        eventsPerSecond: 10
-      }
-    }
-  });
-
-  return browserClient;
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
 }
 
 // Export cu tip pentru utilizare în aplicație


### PR DESCRIPTION
This is an emergency hotfix to address the complete failure of the authentication system (Google, Magic Link) on production. The previous custom singleton implementation in 'browser.ts' was not handling the PKCE code_verifier cookie correctly, leading to an 'invalid request' error from Supabase. This PR replaces the faulty implementation with the standard 'createBrowserClient' from '@supabase/ssr', which is the correct approach for handling auth in the browser with Next.js App Router. This should immediately restore all authentication functionality.